### PR TITLE
Allow CrashReportSender to be overridden via AppContext

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -114,9 +114,11 @@ Future<int> _handleToolError(
       return _exit(1);
     }
 
-    // Report to both [Usage] and [CrashReportSender].
+    final CrashReporter crashReporter = context.get<CrashReporter>();
+
+    // Report to both [Usage] and [CrashReporter].
     globals.flutterUsage.sendException(error);
-    await CrashReportSender.instance.sendReport(
+    await crashReporter.sendReport(
       error: error,
       stackTrace: stackTrace,
       getFlutterVersion: getFlutterVersion,
@@ -127,16 +129,15 @@ Future<int> _handleToolError(
     globals.printError('Oops; flutter has exited unexpectedly: "$errorString".');
 
     try {
-      await CrashReportSender.instance.informUserOfCrash(args, error, stackTrace, errorString);
+      await crashReporter.informUser(args, error, stackTrace, errorString);
 
       return _exit(1);
     // This catch catches all exceptions to ensure the message below is printed.
     } catch (error) { // ignore: avoid_catches_without_on_clauses
       globals.stdio.stderrWrite(
         'Unable to generate crash report due to secondary error: $error\n'
-        'please let us know at https://github.com/flutter/flutter/issues.\n',
-      );
-      // Any exception throw here (including one thrown by `_exit()`) will
+        '${globals.userMessages.flutterToolBugInstructions}\n');
+      // Any exception thrown here (including one thrown by `_exit()`) will
       // get caught by our zone's `onError` handler. In order to avoid an
       // infinite error loop, we throw an error that is recognized above
       // and will trigger an immediate exit.

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -160,7 +160,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
         diagnostics?.add(
           'Unexpected failure parsing device information from adb output:\n'
           '$line\n'
-          'Please report a bug at https://github.com/flutter/flutter/issues/new/choose');
+          '${globals.userMessages.flutterToolBugInstructions}');
       }
     }
   }

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -10,6 +10,10 @@ UserMessages get userMessages => context.get<UserMessages>();
 
 /// Class containing message strings that can be produced by Flutter tools.
 class UserMessages {
+  // Common messages.
+  String get flutterToolBugInstructions =>
+      'Please file a bug at https://github.com/flutter/flutter/issues.';
+
   // Messages used in FlutterValidator
   String flutterStatusInfo(String channel, String version, String os, String locale) =>
       'Channel ${channel ?? 'unknown'}, v${version ?? 'Unknown'}, on $os, locale $locale';

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -124,6 +124,7 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         platform: globals.platform,
       ),
+      CrashReporter: () => CrashReporter(),
       DevFSConfig: () => DevFSConfig(),
       DeviceManager: () => DeviceManager(),
       Doctor: () => const Doctor(),

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -25,7 +25,7 @@ void main() {
     MockGitHubTemplateCreator mockGitHubTemplateCreator;
     setUp(() {
       mockGitHubTemplateCreator = MockGitHubTemplateCreator();
-      CrashReportSender.crashFileSystem = MemoryFileSystem();
+      CrashReporter.crashFileSystem = MemoryFileSystem();
       // Instead of exiting with dart:io exit(), this causes an exception to
       // be thrown, which we catch with the onError callback in the zone below.
       io.setExitFunctionForTests((int _) { throw 'test exit';});
@@ -33,7 +33,7 @@ void main() {
     });
 
     tearDown(() {
-      CrashReportSender.crashFileSystem = const LocalFileSystem();
+      CrashReporter.crashFileSystem = const LocalFileSystem();
       io.restoreExitFunction();
       Cache.enableLocking();
     });


### PR DESCRIPTION
Allow google3 to override `CrashReportSender` via `AppContext` so
that it can customize the `informUserOfCrash` behavior.

Additionally:
* `CrashReportSender` previously wanted to be a singleton, but that
  makes it awkward for `AppContext` to provide a derived version.
  Remove the `initializeWith` factory method and instead make the
  `http.Client` member a settable property on the class.
* Make `_createLocalCrashReport` and `_doctorText` protected so that
  a custom version of `informUserOfCrash` can use them.
  Alternatively we could pass one or both of these as argument to
  `informUserOfCrash`.
* Now that `CrashReportSender` is responsible for reporting crash
  instructions to the user, rename the class to be just
  `CrashReporter`.
* `CrashReporter.informUserOfCrash` seems slightly redundant; rename
  to just `informUser`.
* Move instructions to report bugs on github to an overridable
  `UserMessage`.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

I did need to modify existing tests, but my understanding is that flutter_tools does not strictly follow the breaking change policy.